### PR TITLE
chore: add version policy

### DIFF
--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -99,4 +99,17 @@
   // 
   //   // "includeEmailInChangeFile": true
   // }
+  {
+    "definitionName": "lockStepVersion",
+    "policyName": "xarcAppVersion",
+    "version": "11.0.2",
+    /**
+     * (Required) The type of bump that will be performed when publishing the next release.
+     * When creating a release branch in Git, this field should be updated according to the
+     * type of release.
+     *
+     * Valid values are: "prerelease", "release", "minor", "patch", "major"
+     */
+    "nextBump": "patch"
+  }
 ]

--- a/rush.json
+++ b/rush.json
@@ -531,13 +531,15 @@
       "packageName": "@xarc/app",
       "projectFolder": "packages/xarc-app",
       "shouldPublish": true,
-      "skipRushCheck": true
+      "skipRushCheck": true,
+      "versionPolicyName": "xarcAppVersion"
     },
     {
       "packageName": "@xarc/app-dev",
       "projectFolder": "packages/xarc-app-dev",
       "shouldPublish": true,
-      "skipRushCheck": true
+      "skipRushCheck": true,
+      "versionPolicyName": "xarcAppVersion"
     },
     {
       "packageName": "@xarc/create-app",


### PR DESCRIPTION
Adding version policy to rush for `@xarc/app` and `@xarc/app-dev` to keep the package versions in sync.